### PR TITLE
Allow use of builtin Kibana URL Shortener

### DIFF
--- a/app.py
+++ b/app.py
@@ -154,7 +154,8 @@ def proxy_request(path, **kwargs):
         params=request.query_string,
         data=request.data,
         headers=headers,
-        stream=False
+        stream=False,
+        allow_redirects=False
     )
 
     content = req.content
@@ -192,6 +193,11 @@ def proxy_request(path, **kwargs):
         # "see other"
         return redirect(url, 303)
 
+    elif req.headers.get('Location', False):
+        response = Response(content)
+        response.status_code = 302
+        response.headers['Location'] = req.headers.get('Location')
+        return response
     else:
         # otherwise, just serve it normally
         return Response(content, content_type=req.headers['content-type'])

--- a/app.py
+++ b/app.py
@@ -193,7 +193,7 @@ def proxy_request(path, **kwargs):
         # "see other"
         return redirect(url, 303)
 
-    elif req.headers.get('Location', False):
+    elif req.headers.get('Location', False) and 300 <= req.status_code < 400:
         response = Response(content)
         response.status_code = req.status_code
         response.headers['Location'] = req.headers.get('Location')

--- a/app.py
+++ b/app.py
@@ -195,7 +195,7 @@ def proxy_request(path, **kwargs):
 
     elif req.headers.get('Location', False):
         response = Response(content)
-        response.status_code = 302
+        response.status_code = req.status_code
         response.headers['Location'] = req.headers.get('Location')
         return response
     else:


### PR DESCRIPTION
Because the builtin URL shortener uses redirects, when requests was following the redirect within the lambda instance, the URL signing would fail. By passing the redirected location back to the browser, and letting the browser request the new location, the URL signing works correctly.